### PR TITLE
Update GMT to 5.4.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,12 @@ cp $DCW/* $DATADIR
 
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 
+# Turn on C definition to enable the new GMT modern mode.
+# It doesn't affect current GMT behaviour but adds two new commands: begin and
+# end. Used for testing this new mode.
+cp cmake/ConfigUserTemplate.cmake cmake/ConfigUser.cmake
+echo "add_definitions(-DTEST_MODERN)" >> cmake/ConfigUser.cmake
+
 mkdir build && cd build
 
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.3.3" %}
+{% set version = "5.4.1" %}
 {% set variant = "openblas" %}
 
 package:
@@ -8,10 +8,10 @@ package:
 source:
   fn: gmt-{{ version }}-src.tar.gz
   url: ftp://ftp.soest.hawaii.edu/gmt/gmt-{{ version }}-src.tar.gz
-  sha256: b5e592d7482de5dee06268a0a048949f5cf626ef67b0419515ce3d14f4aa82c6
+  sha256: c85541d50b63a5f0809552edb488bb69995b96dd684df77d6328a9eea7ff3ab0
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win or osx]
   features:
     - blas_{{ variant }}
@@ -26,6 +26,7 @@ requirements:
     - hdf5 1.8.17|1.8.17.*
     - zlib 1.2.*
     - blas 1.1 {{ variant }}
+    - curl
   run:
     - fftw
     - gdal 2.1.*
@@ -34,6 +35,7 @@ requirements:
     - hdf5 1.8.17|1.8.17.*
     - zlib 1.2.*
     - blas 1.1 {{ variant }}
+    - curl
 
 test:
   commands:


### PR DESCRIPTION
Include configuration for a C definition that enables the new GMT [modern mode](http://gmt.soest.hawaii.edu/boards/2/topics/5138). This adds the `gmt begin` and `gmt end` commands and doesn't impact any other part of GMT (so it's harmless if these two commands aren't used).

The modern mode usage is not yet documented but enabling this in the conda package will help test it as well as aid the development of the [python wrappers](https://github.com/GenericMappingTools/gmt-python).

This release adds a dependency on libcurl.