### PR TITLE
Update to 6.0.0a3: Bug fix in "gmt end" chdir

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0.0a2" %}
+{% set version = "6.0.0a3" %}
 {% set variant = "openblas" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   svn_url: svn://gmtserver.soest.hawaii.edu/gmt/trunk
-  svn_rev: 18520
+  svn_rev: 18522
 
 build:
   number: 0


### PR DESCRIPTION
Fixes a bug that left users of the API in the `/tmp` folder after `gmt end`.