### PR TITLE
Update to 6.0.0a4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0.0a3" %}
+{% set version = "6.0.0a4" %}
 {% set variant = "openblas" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   svn_url: svn://gmtserver.soest.hawaii.edu/gmt/trunk
-  svn_rev: 18522
+  svn_rev: 18534
 
 build:
   number: 0


### PR DESCRIPTION
Fixes psconvert error when called twice.
Add new 'gmt subplot' command.