### PR TITLE
[WIP] Update devel and run the tests for GMT/Python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,12 @@ requirements:
     - dcw-gmt
 
 test:
+  requires:
+    - python=3.6
+    - pip
+    - numpy
+    - pytest
+    - pytest-mpl
   commands:
     - gmt psbasemap -R10/70/-3/8 -JX4i/3i -Ba -B+glightred+t"TEST" -P > test0.ps  # [not win]
     - gmt pscoast -Vd -R0/5/0/5 -JM5i -P -W0.25p > test1.ps  # [not win]

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install and run the tests for GMT/Python to make sure the package was built
+# properly.
+
+pip install https://github.com/GenericMappingTools/gmt-python/archive/master.zip
+python -c "import gmt; gmt.test()"


### PR DESCRIPTION
Use this as a test for the GMT package and shared library. Helps keep
things working smoothly between GMT and the wrappers.

Update the dev label to 6.0.0a10 r19443