### PR TITLE
Rebuild with ghostscript as Windows dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 17276edd8fbe16f04bba72717baa5fbd9683a801c94fb69f287bcfe2d1feab84
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - libcblas
     - fftw
     - gdal
-    - ghostscript  # [not win]
+    - ghostscript
     - libnetcdf
     - hdf5
     - zlib
@@ -32,7 +32,7 @@ requirements:
   run:
     - fftw
     - gdal
-    - ghostscript  # [not win]
+    - ghostscript
     - libnetcdf
     - hdf5
     - zlib
@@ -48,9 +48,9 @@ test:
     - gmt defaults -Vd  # [not linux]
     - gmt psbasemap -R10/70/-3/8 -JX4i/3i -Ba -B+glightred+t"TEST" -P -Vd > test0.ps  # [not linux]
     - gmt pscoast -R0/5/0/5 -JM5i -P -W0.25p -Vd > test1.ps  # [not linux]
-    - gmt begin -Vd  # [osx]
-    - gmt coast -R0/5/0/5 -JM5i -W0.25p -Vd  # [osx]
-    - gmt end  # [osx]
+    - gmt begin -Vd  # [not linux]
+    - gmt coast -R0/5/0/5 -JM5i -W0.25p -Vd  # [not linux]
+    - gmt end  # [not linux]
 
 about:
   home: https://www.generic-mapping-tools.org


### PR DESCRIPTION
Trying a build with ghostscript as a dependency on Windows as well. Test with a modern mode command on Windows, which should trigger a call to gs.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
