### PR TITLE
Apply the upstream patch for compatibility with netcdf 4.7.4

### DIFF
--- a/recipe/gmt-6.0.0-patch1.patch
+++ b/recipe/gmt-6.0.0-patch1.patch
@@ -1,0 +1,22 @@
+diff --git src/gmt_nc.c src/gmt_nc.c
+index 7023561dd5..02f4144b95 100644
+--- src/gmt_nc.c
++++ src/gmt_nc.c
+@@ -818,7 +818,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
+ 			header->z_min = header->z_max = 0.0;
+ 		}
+ 		{	/* Get deflation and chunking info */
+-			int storage_mode, shuffle, deflate, deflate_level;
++			int storage_mode, shuffle = 0, deflate = 0, deflate_level = 0;
+ 			size_t chunksize[5]; /* chunksize of z */
+ 			gmt_M_err_trap (nc_inq_var_chunking (ncid, z_id, &storage_mode, chunksize));
+ 			if (storage_mode == NC_CHUNKED) {
+@@ -828,7 +828,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
+ 			else { /* NC_CONTIGUOUS */
+ 				HH->z_chunksize[0] = HH->z_chunksize[1] = 0;
+ 			}
+-			gmt_M_err_trap (nc_inq_var_deflate (ncid, z_id, &shuffle, &deflate, &deflate_level));
++			if (HH->is_netcdf4) gmt_M_err_trap (nc_inq_var_deflate (ncid, z_id, &shuffle, &deflate, &deflate_level));
+ 			HH->z_shuffle = shuffle ? true : false; /* if shuffle filter is turned on */
+ 			HH->z_deflate_level = deflate ? deflate_level : 0; /* if deflate filter is in use */
+ 		}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,12 @@ source:
   patches:
     # patch for GMT 6.0.0 only. See https://github.com/GenericMappingTools/gmt/pull/3361
     - gmt-6.0.0-patch0.patch
+    # patch for GMT 6.0.0 compatibility with netCDF 4.7.4.
+    # See https://github.com/GenericMappingTools/gmt/pull/3023
+    - gmt-6.0.0-patch1.patch
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
GMT 6.0.0 doesn't work well with netcdf 4.7.4. See https://github.com/GenericMappingTools/gmt/pull/3023 for the fix.

To reproduce the bug, run:
```
$ gmt xyz2grd -I1 -R0/3/0/3 -Gtest.nc << EOF
1 1 1
1 1 2
2 1 1
2 2 2
EOF

$ gmt grdinfo test.nc
grdinfo (api_import_grid): NetCDF: Attempting netcdf-4 operation on netcdf-3 file [abc.nc]
[Session gmt (0)]: Error returned from GMT API: GMT_GRID_READ_ERROR (18)
[Session gmt (0)]: Error returned from GMT API: GMT_GRID_READ_ERROR (18)
```


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
