### PR TITLE
Rebuild and add GraphicsMagick back

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ source:
   git_url: https://github.com/GenericMappingTools/gmt.git
   git_rev: 92c567688fc5fa71a935ef1e654b0ee99c41f93a
 build:
-  number: 3
+  number: 4
   skip: True  # [win and vc<14]
 requirements:
   build:
@@ -40,8 +40,7 @@ requirements:
     - gshhg-gmt  # [not win]
     - dcw-gmt  # [not win]
     - ffmpeg
-    # re-add when https://github.com/conda-forge/graphicsmagick-feedstock/pull/11 is merged
-    # - graphicsmagick
+    - graphicsmagick
 test:
   commands:
     - gmt defaults -Vd


### PR DESCRIPTION
conda-forge/graphicsmagick-feedstock#11 is merged, now we can add gm as a GMT dependency.

Same as #124 but for devel branch.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
