### PR TITLE
WIP: Do not package gshhg and dcw data on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,8 +19,8 @@ cmake -G "NMake Makefiles" ^
       -D GMT_LIBDIR=lib ^
       -D DCW_ROOT=%DCW_DIR% ^
       -D GSHHG_ROOT=%GSHHG_DIR% ^
-      -D COPY_GSHHG=TRUE ^
-      -D COPY_DCW=TRUE ^
+      -D COPY_GSHHG=FALSE ^
+      -D COPY_DCW=FALSE ^
       -D GMT_INSTALL_TRADITIONAL_FOLDERNAMES=FALSE ^
       -D GMT_INSTALL_MODULE_LINKS=FALSE ^
       %SRC_DIR%

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ requirements:
     - zlib
     - curl
     - pcre
-    - gshhg-gmt  # [not win]
-    - dcw-gmt  # [not win]
+    - gshhg-gmt
+    - dcw-gmt
     - ffmpeg
     - graphicsmagick
 


### PR DESCRIPTION
On Windows, we have to include the GSHHG and DCW data in the packages, possibly due to an upstream GMT bug. This PR tries to debug it.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
