### PR TITLE
Bump GMT from 6.2.0.dev7+e1b6a15 to 6.2.0.dev8+9273814

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: gmt
-  version: 6.2.0.dev7+e1b6a15
+  version: 6.2.0.dev8+9273814
 source:
   git_url: https://github.com/GenericMappingTools/gmt.git
-  git_rev: e1b6a150f716bb1635576cf73a2012f004d4d06b
+  git_rev: 92738141a65b93fb9b3af8e9fc3f8bf316d7534d
 build:
-  number: 1
+  number: 0
   skip: True  # [win and vc<14]
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
