### PR TITLE
Specify run_exports to pin compatible curl, fftw, gdal and zlib versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,13 @@ source:
   sha256: d267c0c7d6fb30c9ea7e029ef27dadb26ffd7b92cb4b4703f9a3ba0e8f393a1b
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win and vc<14]
+  run_exports:
+    - {{ pin_subpackage('curl', max_pin='x') }}
+    - {{ pin_subpackage('fftw', max_pin='x') }}
+    - {{ pin_subpackage('gdal', max_pin='x.x') }}
+    - {{ pin_subpackage('zlib', max_pin='x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ build:
   number: 5
   skip: true  # [win and vc<14]
   run_exports:
-    - {{ pin_subpackage('curl', max_pin='x') }}
-    - {{ pin_subpackage('fftw', max_pin='x') }}
-    - {{ pin_subpackage('gdal', max_pin='x.x') }}
-    - {{ pin_subpackage('zlib', max_pin='x.x') }}
+    - {{ pin_compatible('curl', max_pin='x') }}
+    - {{ pin_compatible('fftw', max_pin='x') }}
+    - {{ pin_compatible('gdal', max_pin='x.x') }}
+    - {{ pin_compatible('zlib', max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
As `pin_run_as_build` was removed in #226, this led to version incompatibilities with libraries like GDAL, see bug report at https://github.com/GenericMappingTools/pygmt/issues/2215. This PR attempts to pin the runtime dependencies again using `run_exports`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

References:
- https://conda-forge.org/docs/maintainer/pinning_deps.html#specifying-run-exports
- https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements
- https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102