### PR TITLE
Pin versions of fftw, gdal, zlib and curl at runtime

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,9 @@ source:
   git_url: https://github.com/GenericMappingTools/gmt.git
   git_rev: b0c2f6d21da983b6c674e95facca729f69979961
 build:
-  number: 2
-  skip: True  # [win and vc<14]
+  number: 3
+  skip: true  # [win and vc<14]
+
 requirements:
   build:
     - cmake
@@ -31,14 +32,14 @@ requirements:
     - libblas
     - libcblas
     - liblapack
-    - fftw
-    - gdal
+    - {{ pin_compatible('fftw', max_pin='x') }}
+    - {{ pin_compatible('gdal', max_pin='x.x') }}
     - geos
     - ghostscript
     - libnetcdf
     - hdf5
-    - zlib
-    - curl
+    - {{ pin_compatible('zlib', max_pin='x.x') }}
+    - {{ pin_compatible('curl', max_pin='x') }}
     - pcre
     - gshhg-gmt  # [not win]
     - dcw-gmt  # [not win]


### PR DESCRIPTION
Similar to #232 but for the GMT `devel` builds. Addresses the Windows GMT Dev Tests failures mentioned in https://github.com/GenericMappingTools/pygmt/issues/2215.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
