### PR TITLE
Add libgdal-jp2openjpeg dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b17e165fd6c85aeb0a281700bd89522af8c2676a2d7bdb51a6b242fa9f1779c9
 
 build:
-  number: 4
+  number: 3
   skip: true  # [ppc64le]
 
 requirements:
@@ -42,7 +42,6 @@ requirements:
     - {{ pin_compatible('gdal', max_pin='x.x') }}
     - geos
     - ghostscript
-    - libgdal-jp2openjpeg
     - libnetcdf
     - hdf5
     - {{ pin_compatible('zlib', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b17e165fd6c85aeb0a281700bd89522af8c2676a2d7bdb51a6b242fa9f1779c9
 
 build:
-  number: 3
+  number: 4
   skip: true  # [ppc64le]
 
 requirements:
@@ -42,6 +42,7 @@ requirements:
     - {{ pin_compatible('gdal', max_pin='x.x') }}
     - geos
     - ghostscript
+    - libgdal-jp2openjpeg
     - libnetcdf
     - hdf5
     - {{ pin_compatible('zlib', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,8 @@ test:
     - gmt-config --all  # [not win]
     - gmt  # [win]
     - gmt grdmath -Rg -I1 0 90 SDIST = dist_to_NP.nc -x2
+    # Test reading/writing a JP2 file (S90E000.earth_relief_05m_p.jp2)
+    - gmt grdcut @earth_relief_05m -R-10/-9/3/5 -G/tmp/reliefcut.jp2=gd:JP2OpenJPEG
 
 about:
   home: https://www.generic-mapping-tools.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,8 +65,8 @@ test:
     - gmt  # [win]
     - gmt grdmath -Rg -I1 0 90 SDIST = dist_to_NP.nc -x2
     # Test reading/writing a JP2 file (S90E000.earth_relief_05m_p.jp2)
-    - gmt grdcut @earth_relief_05m -R-10/-9/3/5 -G/tmp/reliefcut.jp2=gd:JP2OpenJPEG
-    - "[ -e '/tmp/reliefcut.jp2' ] && exit 0 || exit 1"
+    - gmt grdcut @earth_relief_05m -R-10/-9/3/5 -Greliefcut.jp2=gd:JP2OpenJPEG
+    - "[ -e 'reliefcut.jp2' ] && exit 0 || exit 1"
 
 about:
   home: https://www.generic-mapping-tools.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,7 @@ test:
     - gmt grdmath -Rg -I1 0 90 SDIST = dist_to_NP.nc -x2
     # Test reading/writing a JP2 file (S90E000.earth_relief_05m_p.jp2)
     - gmt grdcut @earth_relief_05m -R-10/-9/3/5 -G/tmp/reliefcut.jp2=gd:JP2OpenJPEG
+    - [ -e "/tmp/reliefcut.jp2" ] && exit 0 || exit 1
 
 about:
   home: https://www.generic-mapping-tools.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ test:
     - gmt grdmath -Rg -I1 0 90 SDIST = dist_to_NP.nc -x2
     # Test reading/writing a JP2 file (S90E000.earth_relief_05m_p.jp2)
     - gmt grdcut @earth_relief_05m -R-10/-9/3/5 -G/tmp/reliefcut.jp2=gd:JP2OpenJPEG
-    - [ -e "/tmp/reliefcut.jp2" ] && exit 0 || exit 1
+    - "[ -e '/tmp/reliefcut.jp2' ] && exit 0 || exit 1"
 
 about:
   home: https://www.generic-mapping-tools.org


### PR DESCRIPTION
Enable reading tiled `.jp2` files from https://docs.generic-mapping-tools.org/latest/datasets/remote-data.html such as `earth_relief`, `mars_relief`, `earth_age`, `mercury_relief`, `earth_faa`, `moon_relief`, `earth_geoid`, `pluto_relief`, `earth_mag`, `venus_relief`, `earth_mag4km`, `earth_wdmam`, `earth_synbath`, `earth_vgg`.

The `gdal` package on conda-forge now depends on `libgdal-core` which is a lightweight version that doesn't include certain drivers. See https://github.com/conda-forge/gdal-feedstock/pull/948 and https://github.com/conda-forge/gdal-feedstock/issues/722.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes https://github.com/GenericMappingTools/pygmt/pull/3328
<!--
Please add any other relevant info below:
-->
