### PR TITLE
Rebuild GMT 6.6 with GDAL 3.10 rather than 3.11

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.10'
+- '3.11'
 libgdal_core:
-- '3.10'
+- '3.11'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.11'
+- '3.10'
 libgdal_core:
-- '3.11'
+- '3.10'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.10'
+- '3.11'
 libgdal_core:
-- '3.10'
+- '3.11'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.11'
+- '3.10'
 libgdal_core:
-- '3.11'
+- '3.10'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.10'
+- '3.11'
 libgdal_core:
-- '3.10'
+- '3.11'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.11'
+- '3.10'
 libgdal_core:
-- '3.11'
+- '3.10'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.10'
+- '3.11'
 libgdal_core:
-- '3.10'
+- '3.11'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.11'
+- '3.10'
 libgdal_core:
-- '3.11'
+- '3.10'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.10'
+- '3.11'
 libgdal_core:
-- '3.10'
+- '3.11'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -29,9 +29,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.11'
+- '3.10'
 libgdal_core:
-- '3.11'
+- '3.10'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -21,9 +21,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.11'
+- '3.10'
 libgdal_core:
-- '3.11'
+- '3.10'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -21,9 +21,9 @@ libblas:
 libcblas:
 - 3.9.* *netlib
 libgdal:
-- '3.10'
+- '3.11'
 libgdal_core:
-- '3.10'
+- '3.11'
 liblapack:
 - 3.9.* *netlib
 libnetcdf:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+libgdal:
+  - '3.10'
+libgdal_core:
+  - '3.10'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 28c0e56a31d8f3606da18a8e7473eb40647b031df21c69a3e42255953c95bfe4
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/pull/4018#issuecomment-3344723998 for context.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
